### PR TITLE
cleaned up redundancy in WINEPREFIX blocks + little improved outputs

### DIFF
--- a/updateorigin.sh
+++ b/updateorigin.sh
@@ -36,7 +36,7 @@ then
     wget "https://download.dm.origin.com/origin/live/OriginSetup.exe"
     echo "Extracting the installation file:"
     unzip OriginSetup.exe 'update/*.zip'
-    unzip -o ./update/*.zip -d "$WINEPREFIX/$PATH32"
+    unzip -o ./update/*.zip -d "$WINEPREFIX/$UPDATEPATH"
     echo "Cleaning up..."
     rm -r ./update
     rm OriginSetup.exe


### PR DESCRIPTION
Yo, as the title says, I optimized the WINEPREFIX blocks a little bit to have a nicer flow with variables and to reduce redundancy

Also a little more output in the terminal to let the user see what happens

Tested with my 64bit Origin prefix, so 32bit has not been tested yet

I'm a bash noob (yet), so don't be too harsh :D